### PR TITLE
Change charms to use juju-http{s}-proxy model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ principal charm.
 See [config.yaml](config.yaml) for
 list of configuration options.
 
-> Note: Setting HTTP proxy values will be overriden if `juju-http-proxy` or `juju-https-proxy` settings are set on the model.
+> Note: Setting HTTP proxy values will be override `juju-http-proxy` or `juju-https-proxy` on the model.
 
 ## Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ principal charm.
 See [config.yaml](config.yaml) for
 list of configuration options.
 
-> Note: Setting HTTP proxy values will be override `juju-http-proxy` or `juju-https-proxy` on the model.
+> Note: Setting HTTP proxy values will override `juju-http-proxy` or `juju-https-proxy` on the model.
 
 ## Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,3 @@ ecosystem.
   - Check the charm-docker
   [issue-tracker](https://github.com/juju-solutions/charm-docker/issues) for
   bugs or problems related to the Charm.
-
-# Testing
-
-When upgrading this charm, the [`docker_runtime_version`](https://github.com/VariableDeclared/jenkins/blob/3bf2cabc7185568e6a80a137a7f083c428048683/jobs/validate-juju-https-envs.yaml#L22) of the `validate-https-proxy-envs` key needs to be updated with the new containerd version.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ ecosystem.
   - Check the charm-docker
   [issue-tracker](https://github.com/juju-solutions/charm-docker/issues) for
   bugs or problems related to the Charm.
+
+# Testing
+
+When upgrading this charm, the [`docker_runtime_version`](https://github.com/VariableDeclared/jenkins/blob/3bf2cabc7185568e6a80a137a7f083c428048683/jobs/validate-juju-https-envs.yaml#L22) of the `validate-https-proxy-envs` key needs to be updated with the new containerd version.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This subordinate charm deploys the [Docker](http://docker.com) engine within
 a running Juju charm application. Docker is an open platform for developers
 and sysadmins to build, ship, and run distributed applications in containers.
 
-Docker containers wrap a piece of software in a complete file system that 
+Docker containers wrap a piece of software in a complete file system that
 contains everything needed to run an application on a server.
 
-Docker focuses on distributing applications as containers that can be quickly 
-assembled from components that are run the same on different servers without 
-environmental dependencies. This eliminates the friction between development, 
+Docker focuses on distributing applications as containers that can be quickly
+assembled from components that are run the same on different servers without
+environmental dependencies. This eliminates the friction between development,
 QA, and production environments.
 
 # States
@@ -25,7 +25,7 @@ The following states are set by this subordinate:
 
 The Docker subordinate charm is to be used with principal
 charms that need a container runtime.  To use, we deploy
-the Docker subordinate charm and then relate it to the 
+the Docker subordinate charm and then relate it to the
 principal charm.
 
 ```
@@ -43,6 +43,8 @@ principal charm.
 See [config.yaml](config.yaml) for
 list of configuration options.
 
+> Note: Setting HTTP proxy values will be overriden if `juju-http-proxy` or `juju-https-proxy` settings are set on the model.
+
 ## Docker Compose
 
 This charm also installs the 'docker-compose' python package using pip. So
@@ -52,17 +54,17 @@ and logging.
 
 # Contact Information
 
-This charm is available at <https://jujucharms.com/docker> and contains the 
-open source operations code to deploy on all public clouds in the Juju 
+This charm is available at <https://jujucharms.com/docker> and contains the
+open source operations code to deploy on all public clouds in the Juju
 ecosystem.
 
 ## Docker links
 
   - The [Docker homepage](https://www.docker.com/)
-  - Docker [documentation](https://docs.docker.com/) for help with Docker 
+  - Docker [documentation](https://docs.docker.com/) for help with Docker
   commands.
   - Docker [forums](https://forums.docker.com/) for community discussions.
-  - Check the Docker [issue tracker](https://github.com/docker/docker/issues) 
+  - Check the Docker [issue tracker](https://github.com/docker/docker/issues)
   for bugs or problems with the Docker software.
   - The [charm-docker](https://github.com/juju-solutions/charm-docker) is
   the GitHub repository that contains the reactive code to build this Charm.

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -297,10 +297,8 @@ def toggle_docker_daemon_source():
         hookenv.log('Not touching packages.')
 
 
-# @when_any('config.changed.http_proxy', 'config.changed.https_proxy',
-#           'config.changed.no_proxy', 'config.changed.juju-http-proxy',
-#           'config.changed.juju-https-proxy', 'config.changed.juju-no-proxy')
-@when('config.changed')
+@when_any('config.changed.http_proxy', 'config.changed.https_proxy',
+          'config.changed.no_proxy')
 @when('docker.ready')
 def proxy_changed():
     """
@@ -983,7 +981,7 @@ def _probe_runtime_availability():
         command = ['docker', 'info']
         check_call(command)
         return True
-    except (CalledProcessError, FileNotFoundError):
+    except (CalledProcessError):
         # Remove the availability state if we fail reachability.
         remove_state('docker.available')
         return False

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -924,10 +924,9 @@ def recycle_daemon():
 
     :return: None
     """
+    charm_config = check_for_juju_https_proxy(config)
 
-    modified_config = check_for_juju_https_proxy(config)
-
-    validate_config(modified_config)
+    validate_config(charm_config)
     hookenv.log('Restarting docker service.')
 
     # Re-render our docker daemon template at this time... because we're
@@ -946,7 +945,7 @@ def recycle_daemon():
     render(
         'docker.systemd',
         '/lib/systemd/system/docker.service',
-        modified_config
+        charm_config
     )
 
     reload_system_daemons()

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -26,10 +26,12 @@ from charmhelpers.fetch import filter_installed_packages
 from charmhelpers.contrib.charmsupport import nrpe
 
 
+
 from charms.reactive import hook
 from charms.reactive import remove_state
 from charms.reactive import set_state
 from charms.reactive import is_state
+from charms.reactive.flags import is_flag_set
 from charms.reactive import when
 from charms.reactive import when_any
 from charms.reactive import when_not
@@ -925,8 +927,9 @@ def recycle_daemon():
     # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
     # &: https://bugs.launchpad.net/charm-layer-docker/+bug/1831712
     environment_config = hookenv.env_proxy_settings()
+    configuration = config()
     if environment_config is not None:
-        config().update(environment_config)
+        configuration.update(environment_config)
 
     hookenv.log("CONFIG: %s" % environment_config)
 

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -180,6 +180,14 @@ def install():
         hookenv.log('Unknown runtime {}'.format(runtime))
         return False
 
+    # If juju environment variables are defined, take precedent
+    # over config.yaml.
+    # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
+    environment_config = hookenv.env_proxy_settings()
+    if environment_config is not None:
+        config.update(environment_config)
+
+
     validate_config()
     opts = DockerOpts()
     render(
@@ -997,4 +1005,3 @@ def _remove_docker_network_bridge():
 
     # Render the config and restart docker.
     recycle_daemon()
-

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -983,7 +983,7 @@ def _probe_runtime_availability():
         command = ['docker', 'info']
         check_call(command)
         return True
-    except (CalledProcessError):
+    except CalledProcessError:
         # Remove the availability state if we fail reachability.
         remove_state('docker.available')
         return False

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -185,7 +185,7 @@ def install():
         hookenv.log('Unknown runtime {}'.format(runtime))
         return False
 
-    validate_config()
+    validate_config(config())
     opts = DockerOpts()
     render(
         'docker.defaults',

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -185,7 +185,9 @@ def install():
         hookenv.log('Unknown runtime {}'.format(runtime))
         return False
 
-    validate_config(config())
+    charm_config = check_for_juju_https_proxy(config)
+    validate_config(charm_config)
+
     opts = DockerOpts()
     render(
         'docker.defaults',
@@ -198,7 +200,7 @@ def install():
     render(
         'docker.systemd',
         '/lib/systemd/system/docker.service',
-        config()
+        charm_config
     )
     reload_system_daemons()
 
@@ -925,8 +927,8 @@ def recycle_daemon():
     :return: None
     """
     charm_config = check_for_juju_https_proxy(config)
-
     validate_config(charm_config)
+
     hookenv.log('Restarting docker service.')
 
     # Re-render our docker daemon template at this time... because we're

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -904,7 +904,7 @@ def manage_docker_opts(opts, remove=False):
     set_state('docker.restart')
 
 
-def validate_config():
+def validate_config(config):
     """
     Check that config is valid.
 
@@ -913,7 +913,7 @@ def validate_config():
     max_line = 2048
     line_prefix_len = len('Environment="NO_PROXY=""')
     remain_len = max_line - line_prefix_len
-    if len(config('no_proxy')) > remain_len:
+    if len(config.get('no_proxy', '')) > remain_len:
         raise ConfigError('no_proxy longer than {} chars.'.format(remain_len))
 
 
@@ -927,7 +927,7 @@ def recycle_daemon():
 
     modified_config = check_for_juju_https_proxy(config)
 
-    validate_config()
+    validate_config(modified_config)
     hookenv.log('Restarting docker service.')
 
     # Re-render our docker daemon template at this time... because we're

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -185,8 +185,7 @@ def install():
     # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
     environment_config = hookenv.env_proxy_settings()
     if environment_config is not None:
-        config.update(environment_config)
-
+        config().update(environment_config)
 
     validate_config()
     opts = DockerOpts()


### PR DESCRIPTION
Changed charm to use juju-http{s}-proxy-settings when these keys are defined.

[LP#1831712](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1831712)