### PR TITLE
Don't use Github internal relative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ principal charm.
 
 # Configuration
 
-See [config.yaml](config.yaml) for
+See [config.yaml](https://api.jujucharms.com/charmstore/v5/~containers/docker/archive/config.yaml) for
 list of configuration options.
 
 ## Docker Compose


### PR DESCRIPTION
The original syntax doesn't work with Charm Store:
https://jaas.ai/u/containers/docker

The link will lead to:
https://jaas.ai/u/containers/config.yaml which is 404