### PR TITLE
Don't try to run docker until it's installed and ready

### DIFF
--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -754,7 +754,7 @@ def remove_nrpe_config():
     for service in services:
         nrpe_setup.remove_check(shortname=service)
 
-
+@when('docker.ready')
 @when('config.changed.docker-logins')
 def docker_logins_changed():
     """


### PR DESCRIPTION
It's currently possible for docker_logins_changed() to be run before docker has actually been installed - in which case it'll fail as there's no docker binary yet available to run.