### PR TITLE
Add support for series upgrade

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -3,5 +3,6 @@ includes:
   - 'layer:basic'
   - 'layer:debug'
   - 'layer:container-runtime-common'
+  - 'layer:status'
   - 'interface:container-runtime'
   - 'interface:docker-registry'

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -94,6 +94,11 @@ def upgrade():
         'Holding docker packages at current revision.')
 
 
+@hook('pre-series-upgrade')
+def pre_series_upgrade():
+    status_set('blocked', 'Series upgrade in progress')
+
+
 def set_custom_docker_package():
     """
     If a custom Docker package is defined, add it to

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -99,6 +99,11 @@ def pre_series_upgrade():
     status_set('blocked', 'Series upgrade in progress')
 
 
+@hook('post-series-upgrade')
+def post_series_upgrade():
+    signal_workloads_start()
+
+
 def set_custom_docker_package():
     """
     If a custom Docker package is defined, add it to

--- a/reactive/docker.py
+++ b/reactive/docker.py
@@ -453,19 +453,19 @@ def install_from_custom_apt():
     if not repo_string:
         message = '`docker_runtime_repo` must be set'
         hookenv.log(message)
-        hookenv.status.blocked(message)
+        status.blocked(message)
         return False
 
     if not key_url:
         message = '`docker_runtime_key_url` must be set'
         hookenv.log(message)
-        hookenv.status.blocked(message)
+        status.blocked(message)
         return False
 
     if not package_name:
         message = '`docker_runtime_package` must be set'
         hookenv.log(message)
-        hookenv.status.blocked(message)
+        status.blocked(message)
         return False
 
     lsb = host.lsb_release()
@@ -837,7 +837,7 @@ def configure_registry():
                 msg = 'Incorrect credentials for docker registry'
             else:
                 msg = 'docker login failed, see juju debug-log'
-            hookenv.status.blocked(msg)
+            status.blocked(msg)
     else:
         hookenv.log('Disabling auth for docker registry: {}.'.format(netloc))
         # NB: it's safe to logout of a registry that was never logged in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,37 +1,5 @@
-import os
-import sys
-from unittest.mock import MagicMock
+import charms.unit_test
 
-# mock dependencies which we don't care about covering in our tests
-ch = MagicMock()
-sys.modules['charmhelpers'] = ch
-sys.modules['charmhelpers.core'] = ch.core
-sys.modules['charmhelpers.core.host'] = ch.core.host
-sys.modules['charmhelpers.core.hookenv'] = ch.core.hookenv
-sys.modules['charmhelpers.core.templating'] = ch.core.templating
-sys.modules['charmhelpers.fetch'] = ch.fetch
-sys.modules['charmhelpers.contrib.charmsupport'] = ch.contrib.charmsupport
 
-charms = MagicMock()
-sys.modules['charms'] = charms
-sys.modules['charms.docker'] = charms.docker
-sys.modules['charms.layer'] = charms.layer
-sys.modules['charms.layer.container_runtime_common'] = charms.layer.container_runtime_common
-sys.modules['charms.reactive'] = charms.reactive
-sys.modules['charms.reactive.helpers'] = charms.reactive.helpers
-
-for decorator in ('when',
-                  'when_all',
-                  'when_any',
-                  'when_not',
-                  'when_none',
-                  'when_not_all',
-                  'not_unless',
-                  'when_file_changed',
-                  'collect_metrics',
-                  'meter_status_changed',
-                  'only_once',
-                  'hook'):
-    setattr(charms.reactive, decorator, lambda *a: lambda f: f)
-
-os.environ['JUJU_MODEL_UUID'] = 'test-1234'
+charms.unit_test.patch_reactive()
+charms.unit_test.patch_module('charms.docker')

--- a/tests/test_docker_reactive.py
+++ b/tests/test_docker_reactive.py
@@ -82,3 +82,7 @@ class TestDocker(TestCase):
         assert docker.status_set.call_count == 0
         docker.pre_series_upgrade()
         assert docker.status_set.call_count == 1
+        with patch('reactive.docker.check_call') as check_call:
+            docker.post_series_upgrade()
+        assert docker.status_set.call_count == 2
+        check_call.assert_called_once_with(['docker', 'info'])

--- a/tests/test_docker_reactive.py
+++ b/tests/test_docker_reactive.py
@@ -9,7 +9,7 @@ class TestDocker(TestCase):
     Docker charm tests.
     """
     def tearDown(self):
-        docker.status_set.reset_mock()
+        docker.status.reset_mock()
 
     @staticmethod
     def test_install():
@@ -79,10 +79,13 @@ class TestDocker(TestCase):
         )
 
     def test_series_upgrade(self):
-        assert docker.status_set.call_count == 0
+        assert docker.status.blocked.call_count == 0
+        assert docker.status.active.call_count == 0
         docker.pre_series_upgrade()
-        assert docker.status_set.call_count == 1
+        assert docker.status.blocked.call_count == 1
+        assert docker.status.active.call_count == 0
         with patch('reactive.docker.check_call') as check_call:
             docker.post_series_upgrade()
-        assert docker.status_set.call_count == 2
+        assert docker.status.blocked.call_count == 1
+        assert docker.status.active.call_count == 1
         check_call.assert_called_once_with(['docker', 'info'])

--- a/tests/test_docker_reactive.py
+++ b/tests/test_docker_reactive.py
@@ -8,6 +8,9 @@ class TestDocker(TestCase):
     """
     Docker charm tests.
     """
+    def tearDown(self):
+        docker.status_set.reset_mock()
+
     @staticmethod
     def test_install():
         """
@@ -74,3 +77,8 @@ class TestDocker(TestCase):
             docker.validate_config,
             invalid_config
         )
+
+    def test_series_upgrade(self):
+        assert docker.status_set.call_count == 0
+        docker.pre_series_upgrade()
+        assert docker.status_set.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     pytest-cov
     flake8
     requests
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands =
     pytest --cov-report term-missing \
         --cov reactive.docker --cov-fail-under 30 \


### PR DESCRIPTION
We can't actually pause the service because the series upgrade hooks run on the subordinates before the principal so doing so could interfere with the pod drain process. So instead, we just set a status to let the Juju admin know that it's ok to proceed.

Part of https://bugs.launchpad.net/charm-docker/+bug/1869944